### PR TITLE
Changes on badges visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,23 @@ WPBadgeDisplay is a WordPress plugin for displaying [Open Badges](http://www.ope
 
 ## Installation
 
-1. Download the WPBadgeDisplay plugin, moving the WPBadger folder into the /wp-content/plugins/ directory on your server, and install it like any other WordPress plugin.
+Download the WPBadgeDisplay plugin, moving the WPBadger folder into the /wp-content/plugins/ directory on your server, and install it like any other WordPress plugin.
 
-2. Add the badge widget to your theme by navigating to Appearance -> Widgets in the WordPress administrative panel. There, you can specify where you'd like to display badges (for example, your theme's main sidebar).
+## Usage
 
-3. Configure the widget by adding the email address badges are associated with, and adding an optional title that will display above your badges.
+1. Add the badge widget to your theme by navigating to Appearance -> Widgets in the WordPress administrative panel. There, you can specify where you'd like to display badges (for example, your theme's main sidebar).
+2. Configure the widget by adding the email address badges are associated with, and adding an optional title that will display above your badges.
+
+Alternatively badges can be added to any page using the [openbadges] tag:
+
+    [openbadges
+       email          = 'user_email@example.com'
+       display        = 'inline|block'
+       show_badgename = 0|1
+       show_badgedesc = 0|1
+    ]
+                 
+    
 
 ## Details
 See the [WPBadgeDisplay wiki](https://github.com/davelester/wpbadgedisplay/wiki) for details on the plugin's roadmap, a list of early adopters and examples, and contact information. If you run into a problem, share your problem on the [issue tracker](https://github.com/davelester/wpbadgedisplay/issues?state=open).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Alternatively badges can be added to any page using the [openbadges] tag:
 
     [openbadges
        email          = 'user_email@example.com'
-       display        = 'inline|block'
+       display        = ''|'inline-block'
        show_badgename = 0|1
        show_badgedesc = 0|1
     ]

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -113,8 +113,11 @@ function wpbadgedisplay_return_embed($badgedata, $options=null) {
 		echo "<h1>" . $group['groupname'] . "</h1>";
 
 		foreach($group['badges'] as $badge) {
-			echo "<h2><a href='" . $badge['criteriaurl'] . "'>". $badge['title'] . "</h2>";
-			echo "<img src='" . $badge['image'] . "' border='0'></a>";
+			$url   = $badge['criteriaurl'];
+			$title = $badge['title'];
+			$image = $badge['image'];
+			echo "<h2><a href='$url'>$title</a></h2>";
+			echo "<a href='$url'><img src='$image' alt='$title' title='$title' border='0'></a>";
 		}
 
 		if (!$group['badges']) {

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -29,6 +29,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 	<p><label for="<?php echo $this->get_field_id('title'); ?>">Title: <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo attribute_escape($title); ?>" /></label></p>
 
 	<p><label for="openbadges_user_id">Email Account: <input class="widefat" id="openbadges_email" name="openbadges_email" type="text" value="<?php echo get_option('openbadges_email'); ?>" /></label></p>
+	
+	<p><label for="openbadges_show_bname">Show badges names: <input class="widefat" id="openbadges_show_bname" name="openbadges_show_bname" type="checkbox" <?php if (get_option('openbadges_show_bname')) echo 'checked="checked"'; ?> /></label></p>
 	<?php
 	}
 
@@ -40,6 +42,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 
 		$openbadgesuserid = wpbadgedisplay_convert_email_to_openbadges_id($_POST['openbadges_email']);
 		update_option('openbadges_user_id', $openbadgesuserid);
+		
+		update_option('openbadges_show_bname', $_POST['openbadges_show_bname']);
 
 		return $instance;
 	}
@@ -53,7 +57,10 @@ class WPBadgeDisplayWidget extends WP_Widget
 			echo $before_title . $title . $after_title;;
 
 		$badgedata = wpbadgedisplay_get_public_backpack_contents(get_option('openbadges_user_id'), null);
-		echo wpbadgedisplay_return_embed($badgedata);
+		$options   = array(
+			'show_bname' => get_option('openbadges_show_bname')
+		);
+		echo wpbadgedisplay_return_embed($badgedata, $options);
 	}
 
 }
@@ -116,7 +123,9 @@ function wpbadgedisplay_return_embed($badgedata, $options=null) {
 			$url   = $badge['criteriaurl'];
 			$title = $badge['title'];
 			$image = $badge['image'];
-			echo "<h2><a href='$url'>$title</a></h2>";
+			if ($options['show_bname']) {
+				echo "<h2><a href='$url'>$title</a></h2>";
+			}
 			echo "<a href='$url'><img src='$image' alt='$title' title='$title' border='0'></a>";
 		}
 
@@ -149,9 +158,10 @@ function wpbadgedisplay_convert_email_to_openbadges_id($email) {
 
 function wpbadgedisplay_read_shortcodes( $atts ) {
 	extract( shortcode_atts( array(
-		'email' => '',
-		'username' => '',
-		'badgename' => ''
+		'email'      => '',
+		'username'   => '',
+		'badgename'  => '',
+		'show_badgename' => 1
 	), $atts ) );
 
 	// Create params array
@@ -183,7 +193,10 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 	do_action('openbadges_shortcode');
 
 	$badgedata = wpbadgedisplay_get_public_backpack_contents($openbadgesuserid);
-	return wpbadgedisplay_return_embed($badgedata);
+	$options = array(
+		'show_bname' => $show_badgename
+	);
+	return wpbadgedisplay_return_embed($badgedata, $options);
 
 	// @todo: github ticket #3, if email or username not specified and shortcode is called
 	// on an author page, automatically retrieve the author email from the plugin

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -39,6 +39,7 @@ class WPBadgeDisplayWidget extends WP_Widget
 	
 	<p><label for="openbadges_show_bname">Show badges name: <input class="widefat" id="openbadges_show_bname" name="openbadges_show_bname" type="checkbox" <?php if (get_option('openbadges_show_bname')) echo 'checked="checked"'; ?> /></label></p>
 	<p><label for="openbadges_show_bdesc">Show badges description: <input class="widefat" id="openbadges_show_bdesc" name="openbadges_show_bdesc" type="checkbox" <?php if (get_option('openbadges_show_bdesc')) echo 'checked="checked"'; ?> /></label></p>
+	<p><label for="openbadges_css_li">Additional badge css: <textarea class="widefat" id="openbadges_css_li" name="openbadges_css_li"><?php echo get_option('openbadges_css_li')?></textarea></label></p>
 	<?php
 	}
 
@@ -54,6 +55,7 @@ class WPBadgeDisplayWidget extends WP_Widget
 		update_option('openbadges_display', $_POST['openbadges_display']);
 		update_option('openbadges_show_bname', $_POST['openbadges_show_bname']);
 		update_option('openbadges_show_bdesc', $_POST['openbadges_show_bdesc']);
+		update_option('openbadges_css_li', $_POST['openbadges_css_li']);
 
 		return $instance;
 	}
@@ -70,7 +72,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 		$options   = array(
 			'show_bname' => get_option('openbadges_show_bname'),
 			'show_bdesc' => get_option('openbadges_show_bdesc'),
-			'display'    => get_option('openbadges_display')
+			'display'    => get_option('openbadges_display'),
+			'css_li'     => get_option('openbadges_css_li')
 		);
 		echo wpbadgedisplay_return_embed($badgedata, $options);
 	}
@@ -127,6 +130,8 @@ function wpbadgedisplay_return_embed($badgedata, $options=null) {
 		$display = 'display: ' . $options['display'] . ' !important;';
 	}
 
+	$css_li = $options['css_li'];
+
 	echo "<style>
 	#wpbadgedisplay_widget img {
 		max-height:80px;
@@ -136,6 +141,7 @@ function wpbadgedisplay_return_embed($badgedata, $options=null) {
 	#wpbadgedisplay_widget li {
 		list-style-type: none;
 		$display
+		$css_li
 	}
 	</style>";
 
@@ -195,7 +201,8 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 		'badgename'  => '',
 		'display'    => '',
 		'show_badgedesc' => 0,
-		'show_badgename' => 1
+		'show_badgename' => 1,
+		'css_li'     => ''
 	), $atts ) );
 
 	// Create params array
@@ -230,7 +237,8 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 	$options = array(
 		'show_bname' => $show_badgename,
 		'show_bdesc' => $show_badgedesc,
-		'display'    => $display
+		'display'    => $display,
+		'css_li'     => $css_li
 	);
 	return wpbadgedisplay_return_embed($badgedata, $options);
 

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -30,6 +30,14 @@ class WPBadgeDisplayWidget extends WP_Widget
 
 	<p><label for="openbadges_user_id">Email Account: <input class="widefat" id="openbadges_email" name="openbadges_email" type="text" value="<?php echo get_option('openbadges_email'); ?>" /></label></p>
 	
+	<p><label for="openbadges_display">Display: 
+	<select class="widefat" id="openbadges_display" name="openbadges_display">
+		<option value=''       <?php if (get_option('openbadges_display') == '') { echo "selected='selected'"; } ?>>Default</option>
+		<option value='block'  <?php if (get_option('openbadges_display') == 'block') { echo "selected='selected'"; } ?>>Block</option>
+		<option value='inline' <?php if (get_option('openbadges_display') == 'inline') { echo "selected='selected'"; } ?>>Inline</option>
+	</select>
+	</label></p>
+	
 	<p><label for="openbadges_show_bname">Show badges names: <input class="widefat" id="openbadges_show_bname" name="openbadges_show_bname" type="checkbox" <?php if (get_option('openbadges_show_bname')) echo 'checked="checked"'; ?> /></label></p>
 	<?php
 	}
@@ -43,6 +51,7 @@ class WPBadgeDisplayWidget extends WP_Widget
 		$openbadgesuserid = wpbadgedisplay_convert_email_to_openbadges_id($_POST['openbadges_email']);
 		update_option('openbadges_user_id', $openbadgesuserid);
 		
+		update_option('openbadges_display', $_POST['openbadges_display']);
 		update_option('openbadges_show_bname', $_POST['openbadges_show_bname']);
 
 		return $instance;
@@ -58,7 +67,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 
 		$badgedata = wpbadgedisplay_get_public_backpack_contents(get_option('openbadges_user_id'), null);
 		$options   = array(
-			'show_bname' => get_option('openbadges_show_bname')
+			'show_bname' => get_option('openbadges_show_bname'),
+			'display'    => get_option('openbadges_display')
 		);
 		echo wpbadgedisplay_return_embed($badgedata, $options);
 	}
@@ -109,15 +119,20 @@ function wpbadgedisplay_get_public_backpack_contents($openbadgesuserid)
 function wpbadgedisplay_return_embed($badgedata, $options=null) {
 
 	// @todo: max-height and max-widget should be plugin configurations
+	$display = '';
+	if ($options['display']) {
+		$display = 'display: ' . $options['display'] . ' !important;';
+	}
+
 	echo "<style>
 	#wpbadgedisplay_widget img {
 		max-height:80px;
 		max-width:80px;
-		display: inline !important;
+		$display
 	}
 	#wpbadgedisplay_widget li {
 		list-style-type: none;
-		display: inline !important;
+		$display
 	}
 	</style>";
 
@@ -171,6 +186,7 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 		'email'      => '',
 		'username'   => '',
 		'badgename'  => '',
+		'display'    => '',
 		'show_badgename' => 1
 	), $atts ) );
 
@@ -204,7 +220,8 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 
 	$badgedata = wpbadgedisplay_get_public_backpack_contents($openbadgesuserid);
 	$options = array(
-		'show_bname' => $show_badgename
+		'show_bname' => $show_badgename,
+		'display'    => $display
 	);
 	return wpbadgedisplay_return_embed($badgedata, $options);
 

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -38,7 +38,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 	</select>
 	</label></p>
 	
-	<p><label for="openbadges_show_bname">Show badges names: <input class="widefat" id="openbadges_show_bname" name="openbadges_show_bname" type="checkbox" <?php if (get_option('openbadges_show_bname')) echo 'checked="checked"'; ?> /></label></p>
+	<p><label for="openbadges_show_bname">Show badges name: <input class="widefat" id="openbadges_show_bname" name="openbadges_show_bname" type="checkbox" <?php if (get_option('openbadges_show_bname')) echo 'checked="checked"'; ?> /></label></p>
+	<p><label for="openbadges_show_bdesc">Show badges description: <input class="widefat" id="openbadges_show_bdesc" name="openbadges_show_bdesc" type="checkbox" <?php if (get_option('openbadges_show_bdesc')) echo 'checked="checked"'; ?> /></label></p>
 	<?php
 	}
 
@@ -53,6 +54,7 @@ class WPBadgeDisplayWidget extends WP_Widget
 		
 		update_option('openbadges_display', $_POST['openbadges_display']);
 		update_option('openbadges_show_bname', $_POST['openbadges_show_bname']);
+		update_option('openbadges_show_bdesc', $_POST['openbadges_show_bdesc']);
 
 		return $instance;
 	}
@@ -68,6 +70,7 @@ class WPBadgeDisplayWidget extends WP_Widget
 		$badgedata = wpbadgedisplay_get_public_backpack_contents(get_option('openbadges_user_id'), null);
 		$options   = array(
 			'show_bname' => get_option('openbadges_show_bname'),
+			'show_bdesc' => get_option('openbadges_show_bdesc'),
 			'display'    => get_option('openbadges_display')
 		);
 		echo wpbadgedisplay_return_embed($badgedata, $options);
@@ -95,6 +98,7 @@ function wpbadgedisplay_get_public_backpack_contents($openbadgesuserid)
 		foreach ($badgesdata->badges as $badge) {
 			$badgedata = array(
 				'title' => $badge->assertion->badge->name,
+				'description' => $badge->assertion->badge->description,
 				'image' => $badge->imageUrl,
 				'criteriaurl' => $badge->assertion->badge->criteria,
 				'issuername' => $badge->assertion->badge->issuer->name,
@@ -144,12 +148,16 @@ function wpbadgedisplay_return_embed($badgedata, $options=null) {
 		foreach($group['badges'] as $badge) {
 			$url   = $badge['criteriaurl'];
 			$title = $badge['title'];
+			$desc  = $badge['description'];
 			$image = $badge['image'];
 			echo "<li>";
 			if ($options['show_bname']) {
 				echo "<h2><a href='$url'>$title</a></h2>";
 			}
-			echo "<a href='$url'><img src='$image' alt='$title' title='$title' border='0'></a>";
+			if ($options['show_bdesc']) {
+				echo "<p>$desc</p>";
+			}
+			echo "<a href='$url'><img src='$image' alt='$title' title='$desc' border='0'></a>";
 			echo "</li>";
 		}
 		echo "</ol>";
@@ -187,6 +195,7 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 		'username'   => '',
 		'badgename'  => '',
 		'display'    => '',
+		'show_badgedesc' => 0,
 		'show_badgename' => 1
 	), $atts ) );
 
@@ -221,6 +230,7 @@ function wpbadgedisplay_read_shortcodes( $atts ) {
 	$badgedata = wpbadgedisplay_get_public_backpack_contents($openbadgesuserid);
 	$options = array(
 		'show_bname' => $show_badgename,
+		'show_bdesc' => $show_badgedesc,
 		'display'    => $display
 	);
 	return wpbadgedisplay_return_embed($badgedata, $options);

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -109,25 +109,35 @@ function wpbadgedisplay_get_public_backpack_contents($openbadgesuserid)
 function wpbadgedisplay_return_embed($badgedata, $options=null) {
 
 	// @todo: max-height and max-widget should be plugin configurations
-	echo "<style>#wpbadgedisplay_widget img {
+	echo "<style>
+	#wpbadgedisplay_widget img {
 		max-height:80px;
 		max-width:80px;
-	}</style>";
+		display: inline !important;
+	}
+	#wpbadgedisplay_widget li {
+		list-style-type: none;
+		display: inline !important;
+	}
+	</style>";
 
 	echo "<div id='wpbadgedisplay_widget'>";
 
 	foreach ($badgedata as $group) {
 		echo "<h1>" . $group['groupname'] . "</h1>";
-
+		echo "<ol>";
 		foreach($group['badges'] as $badge) {
 			$url   = $badge['criteriaurl'];
 			$title = $badge['title'];
 			$image = $badge['image'];
+			echo "<li>";
 			if ($options['show_bname']) {
 				echo "<h2><a href='$url'>$title</a></h2>";
 			}
 			echo "<a href='$url'><img src='$image' alt='$title' title='$title' border='0'></a>";
+			echo "</li>";
 		}
+		echo "</ol>";
 
 		if (!$group['badges']) {
 			echo "No badges have been added to this group.";

--- a/wpbadgedisplay.php
+++ b/wpbadgedisplay.php
@@ -32,9 +32,8 @@ class WPBadgeDisplayWidget extends WP_Widget
 	
 	<p><label for="openbadges_display">Display: 
 	<select class="widefat" id="openbadges_display" name="openbadges_display">
-		<option value=''       <?php if (get_option('openbadges_display') == '') { echo "selected='selected'"; } ?>>Default</option>
-		<option value='block'  <?php if (get_option('openbadges_display') == 'block') { echo "selected='selected'"; } ?>>Block</option>
-		<option value='inline' <?php if (get_option('openbadges_display') == 'inline') { echo "selected='selected'"; } ?>>Inline</option>
+		<option value=''             <?php if (get_option('openbadges_display') == '') { echo "selected='selected'"; } ?>>Badges on independent lines</option>
+		<option value='inline-block' <?php if (get_option('openbadges_display') == 'inline-block') { echo "selected='selected'"; } ?>>Several badges on the same line</option>
 	</select>
 	</label></p>
 	


### PR DESCRIPTION
Hi!

I did some changes on the way badges are visualized:
- Ability to show/hide badges title.
- Ability to show/hide badges description.
- Badges are a list.
- Several badges can be displayed on the same line.
- Badge css can be personalized.

I put a couple examples in the attached image:
![badges_examples](https://f.cloud.github.com/assets/1056061/201031/1afb33ba-80e2-11e2-840b-df3e270a7630.png)

Best Regards,
David EG
